### PR TITLE
MET cut correction

### DIFF
--- a/Analysis/HWWAnalysis/HWWAnalysis.C
+++ b/Analysis/HWWAnalysis/HWWAnalysis.C
@@ -177,7 +177,7 @@ Bool_t HWWAnalysis::Process(Long64_t entry)
 				    {
 				      
 				      // cut on 85% WP
-				      if ( jet_MV2c10->at(i) > 0.1758475  && TMath::Abs(jet_eta->at(i)) < 2.5 )
+				      if ( jet_MV2c10->at(i) > 0.1758475 )
 					{
 					  goodbjet_n++;
 					  goodbjet_index[bjet_index] = i;
@@ -204,7 +204,7 @@ Bool_t HWWAnalysis::Process(Long64_t entry)
 			  }
 			  
 			  //  remove low mass meson resonances and DY events; ggF regions, at least 1 jet
-			  if ( mLL > 10 && goodjet_n <= 1 && MET > 20)
+			  if ( mLL > 10 && goodjet_n <= 1 && MET > 30)
 			    {
 			      if ( dPhiLLmet > TMath::Pi()/2 )
 				{


### PR DESCRIPTION
The missing transverse moment according to [ATL-OREACH-PUB-2020-001](https://cds.cern.ch/record/2707171/files/ANA-OTRC-2019-01-PUB-updated.pdf) must be greater than 30GeV. On the other hand, the condition that the pseudo-speed is less than 2.5 was already imposed in the outermost conditional for the selection of jets.