### PR TITLE
Avoid crash when processing on mac

### DIFF
--- a/Analysis/ZBosonAnalysis/ZBosonAnalysis.C
+++ b/Analysis/ZBosonAnalysis/ZBosonAnalysis.C
@@ -99,6 +99,8 @@ Bool_t ZBosonAnalysis::Process(Long64_t entry)
                       {
 			 if( TMath::Abs(lep_trackd0pvunbiased->at(i))/lep_tracksigd0pvunbiased->at(i) < 5 && TMath::Abs(lep_z0->at(i)*TMath::Sin(leptemp.Theta())) < 0.5) {
        	                    goodlep_n = goodlep_n + 1;
+  			 // goodlep_index array can hold two items only
+			   if (lep_index < 2)
 		    	    goodlep_index[lep_index] = i;
 			    lep_index++;
 		         }
@@ -107,7 +109,9 @@ Bool_t ZBosonAnalysis::Process(Long64_t entry)
 		      if ( lep_type->at(i) == 13 && TMath::Abs(lep_eta->at(i)) < 2.5 ) { 
                         if( TMath::Abs(lep_trackd0pvunbiased->at(i))/lep_tracksigd0pvunbiased->at(i) < 3 && TMath::Abs(lep_z0->at(i)*TMath::Sin(leptemp.Theta())) < 0.5) {		
 	                   goodlep_n = goodlep_n + 1;
-			   goodlep_index[lep_index] = i;
+				 // goodlep_index array can hold two items only
+			   if (lep_index < 2)
+			       goodlep_index[lep_index] = i;
 			   lep_index++;
 		        }
 		      }


### PR DESCRIPTION
On a Mac (13.5.1), using ROOT 6.28/04  I get a very fast execution (Behind the scenes I get a crash) when running the Z Boson analysis on the `2lep/MC/mc_361106.Zee.2lep.root` sample.

I am running Option 4, for that MC sample then Option 0 for "no PROOF" when using `run.sh` in ZBosonAnalysis.

The crash is due to undefined behaviour, as some events have more than 2 good leptons and the `goodlep_index` is an array that is only two elements long.  When we write outside of this (e.g. for the third good lepton), the event crashes the event loop.  Later in the code we only analysis events that have exactly two good leptons, so we only need to populate this array with the leading two good leptons.

I have added an if check to both places where the code writes, which protects from writing a third good lepton to the array.

There is no difference to the "physics" output.  Due to the later check on exactly two good leptons.