### PR TITLE
Moving to root:// paths for eos files

### DIFF
--- a/Analysis/HWWAnalysis/main_HWWAnalysis.C
+++ b/Analysis/HWWAnalysis/main_HWWAnalysis.C
@@ -7,7 +7,7 @@
 void main_HWWAnalysis(int proof = 0, int option= 0)
 {
   /* The URL to the CERN Open Data portal repository */
-  TString path = "/eos/opendata/atlas/rucio/opendata/";
+  TString path = "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/";
  
   //***************************************************************************************************//
   // adding chains of all MC and data samples

--- a/Analysis/TTbarAnalysis/main_TTbarAnalysis.C
+++ b/Analysis/TTbarAnalysis/main_TTbarAnalysis.C
@@ -7,7 +7,7 @@
 void main_TTbarAnalysis(int proof = 0, int option= 0){
 
   /* The URL to the CERN Open Data portal repository */
-  TString path = "/eos/opendata/atlas/rucio/opendata/";
+  TString path = "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/";
   
   //***************************************************************************************************//
   // adding chains of all MC and data samples

--- a/Analysis/TTbarDilepAnalysis/main_TTbarDilepAnalysis.C
+++ b/Analysis/TTbarDilepAnalysis/main_TTbarDilepAnalysis.C
@@ -7,7 +7,7 @@
 void main_TTbarDilepAnalysis(int proof = 0, int option= 0)
 {
   /* The URL to the CERN Open Data portal repository */
-  TString path = "/eos/opendata/atlas/rucio/opendata/";
+  TString path = "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/";
   
   //***************************************************************************************************//
   // adding chains of all MC and data samples

--- a/Analysis/ZTauTauAnalysis/main_ZTauTauAnalysis.C
+++ b/Analysis/ZTauTauAnalysis/main_ZTauTauAnalysis.C
@@ -7,7 +7,7 @@
 void main_ZTauTauAnalysis(int proof = 0, int option= 0){
   
   /* The URL to the CERN Open Data portal repository */
-  TString path = "/eos/opendata/atlas/rucio/opendata/";
+  TString path = "root://eospublic.cern.ch//eos/opendata/atlas/rucio/opendata/";
   
   //***************************************************************************************************//
   // Adding chains of all MC and data samples


### PR DESCRIPTION
This allows files to be remote-read in case someone doesn't have /eos mounted (e.g. if they aren't running at CERN). On my laptop, this allows me to directly run the analyses in the Docker container explained in the README, with nothing else mounted, copied, or installed.